### PR TITLE
Added Enable/Disable hook for sprockets

### DIFF
--- a/Extensions/HelpSprocket/Help.cs
+++ b/Extensions/HelpSprocket/Help.cs
@@ -23,5 +23,7 @@ namespace HelpSprocket
 
 			return false;
 		}
+
+	    public bool Enabled { get; set; }
 	}
 }

--- a/Jabbot.AspNetBotHost/Bootstrapper.cs
+++ b/Jabbot.AspNetBotHost/Bootstrapper.cs
@@ -6,6 +6,7 @@ using System.Web.Hosting;
 using Jabbot.Sprockets.Core;
 using Nancy;
 using TinyMessenger;
+using System.Linq;
 
 namespace Jabbot.AspNetBotHost
 {
@@ -22,7 +23,7 @@ namespace Jabbot.AspNetBotHost
 
             container.Register(mefcontainer.GetExportedValues<IAnnounce>());
             container.Register(mefcontainer.GetExportedValues<ISprocketInitializer>());
-            container.Register(mefcontainer.GetExportedValues<ISprocket>());
+            container.Register(new SprocketManager(mefcontainer.GetExportedValues<ISprocket>()));
             container.Register(new Bot(_serverUrl, _botName, _botPassword));
         }
 

--- a/Jabbot.AspNetBotHost/Jabbot.AspNetBotHost.csproj
+++ b/Jabbot.AspNetBotHost/Jabbot.AspNetBotHost.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Bootstrapper.cs" />
     <Compile Include="Modules\HttpObject.cs" />
     <Compile Include="Modules\TalkMessage.cs" />
+    <Compile Include="SprocketManager.cs" />
     <Compile Include="TinyMessenger.cs" />
     <Compile Include="Modules\BotHostModule.cs" />
     <Compile Include="Modules\HomeModule.cs" />

--- a/Jabbot.AspNetBotHost/Modules/BotHostModule.cs
+++ b/Jabbot.AspNetBotHost/Modules/BotHostModule.cs
@@ -99,6 +99,18 @@ namespace Jabbot.AspNetBotHost.Modules
                                       return Response.AsRedirect("/");
                                   };
 
+            Post["/disable/{sprocket}"] = _ =>
+                                              {
+                                                  _bot.DisableSprocket(_.Sprocket);
+                                                  return Response.AsRedirect("/");
+                                              };
+
+            Post["/enable/{sprocket}"] = _ =>
+                                              {
+                                                  _bot.EnableSprocket(_.Sprocket);
+                                                  return Response.AsRedirect("/");
+                                              };
+
         }
 
 

--- a/Jabbot.AspNetBotHost/Modules/HomeModule.cs
+++ b/Jabbot.AspNetBotHost/Modules/HomeModule.cs
@@ -6,7 +6,7 @@ namespace Jabbot.AspNetBotHost.Modules
 {
     public class HomeModule : NancyModule
     {
-        public HomeModule(IEnumerable<IAnnounce> announcers, IEnumerable<ISprocket> sprockets, Bot bot)
+        public HomeModule(IEnumerable<IAnnounce> announcers, SprocketManager sprockets, Bot bot)
         {
             Get["/"] = _ => View["Home/Index", new { Announcers = announcers, Sprockets = sprockets, Bot = bot }];
             Get["/Rooms"] = _ => View["Home/Rooms", bot.Rooms];

--- a/Jabbot.AspNetBotHost/SprocketManager.cs
+++ b/Jabbot.AspNetBotHost/SprocketManager.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Jabbot.Sprockets.Core;
+
+namespace Jabbot.AspNetBotHost
+{
+    public class SprocketManager : Dictionary<int, ISprocket>
+    {
+        public SprocketManager(IEnumerable<ISprocket> sprockets)
+        {
+            var count = 0;
+            foreach (var sprocket in sprockets)
+            {
+                base.Add(count++, sprocket);
+            }
+        }
+    }
+}

--- a/Jabbot.AspNetBotHost/Views/Home/Index.cshtml
+++ b/Jabbot.AspNetBotHost/Views/Home/Index.cshtml
@@ -5,11 +5,11 @@
 }
 <h3>Sprockets</h3>
 <ul>
-    @foreach (var m in Model.Sprockets)
+    @foreach (var kvp in Model.Sprockets)
     {
-        string enabledText = m.Enabled ? "Disable" : "Enable";
-         <form method="POST" action="/bot/@enabledText/@m">
-             <li>@m
+        string enabledText = kvp.Value.Enabled ? "Disable" : "Enable";
+         <form method="POST" action="/bot/@enabledText/@kvp.Key">
+             <li>@kvp.Value
                     <input type="submit" value="@enabledText"/>
              </li>
             </form>

--- a/Jabbot.AspNetBotHost/Views/Home/Index.cshtml
+++ b/Jabbot.AspNetBotHost/Views/Home/Index.cshtml
@@ -7,7 +7,12 @@
 <ul>
     @foreach (var m in Model.Sprockets)
     {
-        <li>@m</li>
+        string enabledText = m.Enabled ? "Disable" : "Enable";
+         <form method="POST" action="/bot/@enabledText/@m">
+             <li>@m
+                    <input type="submit" value="@enabledText"/>
+             </li>
+            </form>
     }
 </ul>
 

--- a/Jabbot.CommandSprockets/CommandSprocket.cs
+++ b/Jabbot.CommandSprockets/CommandSprocket.cs
@@ -46,5 +46,7 @@ namespace Jabbot.CommandSprockets
             }
             return false;
         }
+
+        public bool Enabled { get; set; }
     }
 }

--- a/Jabbot/Bot.cs
+++ b/Jabbot/Bot.cs
@@ -62,21 +62,21 @@ namespace Jabbot
         }
 
         /// <summary>
-        /// Enable a specific sprocket specified by Type Name
+        /// Enable a specific sprocket
         /// </summary>
-        /// <param name="sprocketTypeName">The Type Name of the sprocket (what's returned by mySprocket.GetType().FullName</param>
-        public void EnableSprocket(string sprocketTypeName)
+        /// <param name="sprocket">The sprocket to enable</param>
+        public void EnableSprocket(ISprocket sprocket)
         {
-               SetSprocketEnabled(sprocketTypeName,true);
+               SetSprocketEnabled(sprocket,true);
         }
 
         /// <summary>
-        /// Disable a specific sprocket specified by Type Name
+        /// Disable a specific sprocket
         /// </summary>
-        /// <param name="sprocketTypeName">The Type Name of the sprocket (what's returned by mySprocket.GetType().FullName</param>
-        public void DisableSprocket(string sprocketTypeName)
+        /// <param name="sprocket">The sprocket to disable</param>
+        public void DisableSprocket(ISprocket sprocket)
         {
-            SetSprocketEnabled(sprocketTypeName, false);
+            SetSprocketEnabled(sprocket, false);
         }
 
         /// <summary>
@@ -532,17 +532,20 @@ namespace Jabbot
             _chat.Invoke("send", command).Wait();
         }
 
-        private void SetSprocketEnabled(string sprocketTypeName, bool enabled)
+        private void SetSprocketEnabled(ISprocket sprocket, bool enabled)
         {
-            if (String.IsNullOrEmpty(sprocketTypeName))
+            if (sprocket == null)
             {
                 return;
             }
 
-            foreach (var sprocket in _sprockets.Where(s => s.GetType().FullName == sprocketTypeName))
+            var sprocketToChange = _sprockets.FirstOrDefault(s => s == sprocket);
+            if(sprocketToChange == null)
             {
-                sprocket.Enabled = enabled;
+                return;
             }
+
+            sprocketToChange.Enabled = enabled;
         }
     }
 }

--- a/Jabbot/Sprockets/Core/ISprocket.cs
+++ b/Jabbot/Sprockets/Core/ISprocket.cs
@@ -9,6 +9,6 @@ namespace Jabbot.Sprockets.Core
     [InheritedExport]
     public interface ISprocket : IMessageHandler
     {
-
+        bool Enabled { get; set; }
     }
 }

--- a/Jabbot/Sprockets/RegexSprocket.cs
+++ b/Jabbot/Sprockets/RegexSprocket.cs
@@ -27,5 +27,7 @@ namespace Jabbot.Sprockets
         }
 
         protected abstract void ProcessMatch(Match match, ChatMessage message, IBot bot);
+
+        public bool Enabled { get; set; }
     }
 }


### PR DESCRIPTION
The ISprocket interface now has an Enabled property. In the Bot, this property is set to true when starting up. Whenever the bot is sent a message, while it's looping through the list of ISprockets, it checks this flag. The bot now also has Enable/Disable methods to enable/disable specific sprockets. For now it just takes in a string (ISprocket.GetType().FullName) as there's no easy way to identify a Sprocket (maybe we should add a "SprocketName" or something, food for thought....). I also updated the AspNetBotHost web app with Enable/Disable buttons on the Index page alongside the Sprockets listed.
